### PR TITLE
Split into two packages

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -112,4 +112,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CJ-Wright @tschoonj
+* @CJ-Wright @t20100 @tschoonj @vallsv

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-About silx
-==========
+About silx-base
+===============
 
 Home: https://github.com/silx-kit/silx
 
@@ -137,20 +137,21 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-silx-green.svg)](https://anaconda.org/conda-forge/silx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/silx.svg)](https://anaconda.org/conda-forge/silx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/silx.svg)](https://anaconda.org/conda-forge/silx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/silx.svg)](https://anaconda.org/conda-forge/silx) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-silx--base-green.svg)](https://anaconda.org/conda-forge/silx-base) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/silx-base.svg)](https://anaconda.org/conda-forge/silx-base) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/silx-base.svg)](https://anaconda.org/conda-forge/silx-base) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/silx-base.svg)](https://anaconda.org/conda-forge/silx-base) |
 
-Installing silx
-===============
+Installing silx-base
+====================
 
-Installing `silx` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `silx-base` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `silx` can be installed with:
+Once the `conda-forge` channel has been enabled, `silx, silx-base` can be installed with:
 
 ```
-conda install silx
+conda install silx silx-base
 ```
 
 It is possible to list all of the versions of `silx` available on your platform with:
@@ -198,17 +199,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating silx-feedstock
-=======================
+Updating silx-base-feedstock
+============================
 
-If you would like to improve the silx recipe or build a new
+If you would like to improve the silx-base recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/silx-feedstock are
+Note that all branches in the conda-forge/silx-base-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.
@@ -224,5 +225,7 @@ Feedstock Maintainers
 =====================
 
 * [@CJ-Wright](https://github.com/CJ-Wright/)
+* [@t20100](https://github.com/t20100/)
 * [@tschoonj](https://github.com/tschoonj/)
+* [@vallsv](https://github.com/vallsv/)
 

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,3 @@
+%PYTHON% -m pip install . -vv --no-deps --ignore-installed --global-option build --global-option --force-cython 
+if errorlevel 1 exit 1
+

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "PYTHON: $PYTHON"
+$PYTHON -m pip install . -vv --no-deps --ignore-installed --global-option build --global-option --force-cython 
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 {% set sha256 = "2346ee44eb65ffa23c82d86f401282ea0fde0b813f897f178d901ec09889b9dc" %}
 
 package:
-  name: {{ name|lower }}
+  name: silx-base
   version: {{ version }}
 
 source:
@@ -12,39 +12,57 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . -vv --global-option build --global-option --force-cython "
+  number: 1
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-  host:
-    - cython
-    - pip
-    - python
-    - setuptools
-    - numpy >=1.12
+outputs:
+  - name: silx-base
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    build:
+      entry_points:
+        - silx = silx.__main__:main
 
-  run:
-    - python
-    - setuptools
-    - {{ pin_compatible('numpy') }}
-    - fabio >=0.7
-    - h5py
-    - six
-    - mako
-    - ipython
-    - qtconsole
-    - matplotlib >=1.2.0
-    - python-dateutil
-    # optional dep causing lots of problems
-    #- pyopengl
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - cython
+        - pip
+        - python
+        - setuptools
+        - numpy >=1.12
+      run:
+        - python
+        - setuptools
+        - {{ pin_compatible('numpy') }}
+        - fabio >=0.9
+        - h5py
+        - six
+        - enum34  # [py2k]
+        - futures  # [py2k]
 
-test:
-  imports:
-    - silx
-    - silx.test
+    test:
+      imports:
+        - silx
+        - silx.test
+
+  - name: silx
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('silx-base', exact=True) }}
+        - mako
+        - ipython
+        - qtconsole
+        - matplotlib
+        - python-dateutil
+        - pyqt
+        - scipy
+        - pillow
+        # optional dep causing lots of problems
+        #- pyopengl
 
 about:
   home: https://github.com/silx-kit/silx


### PR DESCRIPTION
Until now a conda installation of silx resulted in an installation with
almost all required and optional dependencies. This commit splits the
package into silx and silx-base, with the latter containing all actual
Python code and binaries, but dragging in only the minimal dependencies
necessary to run silx. silx drags in everything, just like before.

@CJ-Wright @vallsv @t20100 

What do you think about this? I would like do something similar with PyFAI, when you approve of this change...